### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -11,13 +11,13 @@ source:
   sha256: 59b7ec9ac0f714730cbcdde435b7d9b415d3fc3c5d2133e0f124e07aba4ba86a
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: python -m pip install . -vv
 
 requirements:
   host:
-    - python ${{ python_min }}
+    - python ${{ python_min }}.*
     - setuptools >=42
     - wheel
     - pip
@@ -31,7 +31,7 @@ tests:
       imports:
         - schedulefree
       pip_check: true
-      python_version: ${{ python_min }}
+      python_version: ${{ python_min }}.*
 
 about:
   summary: Schedule Free Learning in PyTorch


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.